### PR TITLE
Improve css styling

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -7,6 +7,7 @@ import { MarkdownRenderer } from "obsidian";
 import NoteInfo from "services/NoteInfo";
 import PopperSelectPortal from "components/portals/PopperSelectPortal";
 import { CellContext } from "components/contexts/CellContext";
+import { c } from "helpers/StylesHelper";
 
 /**
  * Obtain the path of the file inside cellValue
@@ -117,7 +118,8 @@ export default function DefaultCell(cellProperties: Cell) {
             null
           );
         });
-        return <span ref={containerRef}></span>;
+
+        return <span ref={containerRef} className={`${c("md_cell")}`} ></span>;
       /** Selector option */
       case DataTypes.SELECT:
         return (

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -4,7 +4,7 @@ import {
   TableDataType,
 } from "cdm/FolderModel";
 import { ActionTypes, DataTypes, StyleVariables } from "helpers/Constants";
-import { dbTrim } from "helpers/StylesHelper";
+import { dbTrim, c } from "helpers/StylesHelper";
 import ArrowUpIcon from "components/img/ArrowUp";
 import ArrowDownIcon from "components/img/ArrowDown";
 import ArrowLeftIcon from "components/img/ArrowLeft";
@@ -282,7 +282,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
           {...attributes.popper}
         >
           <div
-            className="shadow-5 border-radius-md"
+            className={`menu ${c("popper")}`}
             style={{
               width: 240,
               backgroundColor: StyleVariables.BACKGROUND_SECONDARY,
@@ -365,7 +365,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             {/** Action buttons section */}
             <div
               style={{
-                borderTop: `2px solid ${StyleVariables.BACKGROUND_DIVIDER}`,
+                borderTop: `1px solid ${StyleVariables.BACKGROUND_DIVIDER}`,
                 padding: "4px 0px",
               }}
             >
@@ -385,7 +385,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             </div>
             <div
               style={{
-                borderTop: `2px solid ${StyleVariables.BACKGROUND_DIVIDER}`,
+                borderTop: `1px solid ${StyleVariables.BACKGROUND_DIVIDER}`,
                 padding: "4px 0px",
               }}
             >
@@ -437,8 +437,9 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             </div>
           </div>
         </div>
-      )}
-    </div>
+      )
+      }
+    </div >
   );
 };
 

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -319,9 +319,8 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             </div>
             {/** Type of column section */}
             <div style={{ padding: "4px 0px" }}>
-              <button
+              <div
                 className="menu-item sort-button"
-                type="button"
                 onMouseEnter={() => setShowType(true)}
                 onMouseLeave={() => setShowType(false)}
                 ref={setTypeReferenceElement}
@@ -332,7 +331,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                 <span style={{ textTransform: "capitalize" }}>
                   {column.dataType}
                 </span>
-              </button>
+              </div>
               {showType && (
                 <div
                   className={`menu ${c("popper")}`}
@@ -349,12 +348,12 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                 >
                   {types.map((type) => (
                     <div key={type.label}>
-                      <button className="menu-item sort-button" onClick={type.onClick}>
+                      <div className="menu-item sort-button" onClick={type.onClick}>
                         <span className="svg-icon svg-text icon-margin">
                           {type.icon}
                         </span>
                         {type.label}
-                      </button>
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -368,9 +367,8 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
               }}
             >
               {buttons.map((button) => (
-                <button
+                <div
                   key={button.label}
-                  type="button"
                   className="menu-item sort-button"
                   onMouseDown={button.onClick}
                 >
@@ -378,7 +376,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                     {button.icon}
                   </span>
                   {button.label}
-                </button>
+                </div>
               ))}
             </div>
             <div
@@ -389,9 +387,8 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             >
               {/** Column settings section */}
               <div style={{ padding: "4px 0px" }}>
-                <button
+                <div
                   className="menu-item sort-button"
-                  type="button"
                   onMouseEnter={() => setShowSettings(true)}
                   onMouseLeave={() => setShowSettings(false)}
                   ref={setSettingsReferenceElement}
@@ -400,7 +397,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                     <AdjustmentsIcon />
                   </span>
                   <span>Settings</span>
-                </button>
+                </div>
                 {showSettings && (
                   <div
                     className={`menu ${c("popper")}`}

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -284,8 +284,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
           <div
             className={`menu ${c("popper")}`}
             style={{
-              width: 240,
-              backgroundColor: StyleVariables.BACKGROUND_SECONDARY,
+              width: 240
             }}
           >
             {/** Edit header label section */}
@@ -321,7 +320,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
             {/** Type of column section */}
             <div style={{ padding: "4px 0px" }}>
               <button
-                className="sort-button"
+                className="menu-item sort-button"
                 type="button"
                 onMouseEnter={() => setShowType(true)}
                 onMouseLeave={() => setShowType(false)}
@@ -336,7 +335,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
               </button>
               {showType && (
                 <div
-                  className="shadow-5 border-radius-m"
+                  className={`menu ${c("popper")}`}
                   ref={setTypePopperElement}
                   onMouseEnter={() => setShowType(true)}
                   onMouseLeave={() => setShowType(false)}
@@ -344,14 +343,13 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                   style={{
                     ...typePopper.styles.popper,
                     width: 200,
-                    backgroundColor: StyleVariables.BACKGROUND_SECONDARY,
                     zIndex: 4,
                     padding: "4px 0px",
                   }}
                 >
                   {types.map((type) => (
                     <div key={type.label}>
-                      <button className="sort-button" onClick={type.onClick}>
+                      <button className="menu-item sort-button" onClick={type.onClick}>
                         <span className="svg-icon svg-text icon-margin">
                           {type.icon}
                         </span>
@@ -373,7 +371,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                 <button
                   key={button.label}
                   type="button"
-                  className="sort-button"
+                  className="menu-item sort-button"
                   onMouseDown={button.onClick}
                 >
                   <span className="svg-icon svg-text icon-margin">
@@ -392,7 +390,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
               {/** Column settings section */}
               <div style={{ padding: "4px 0px" }}>
                 <button
-                  className="sort-button"
+                  className="menu-item sort-button"
                   type="button"
                   onMouseEnter={() => setShowSettings(true)}
                   onMouseLeave={() => setShowSettings(false)}
@@ -405,7 +403,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                 </button>
                 {showSettings && (
                   <div
-                    className="shadow-5 border-radius-m"
+                    className={`menu ${c("popper")}`}
                     ref={setSettingsPopperElement}
                     onMouseEnter={() => setShowSettings(true)}
                     onMouseLeave={() => setShowSettings(false)}
@@ -413,7 +411,6 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                     style={{
                       ...settingsPopper.styles.popper,
                       width: 200,
-                      backgroundColor: StyleVariables.BACKGROUND_SECONDARY,
                       zIndex: 4,
                       padding: "4px 0px",
                     }}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import CsvButton from "components/CsvButton";
 import { CsvButtonProps, GlobalFilterProps } from "cdm/MenuBarModel";
 import GlobalFilter from "components/reducers/GlobalFilter";
+import { StyleVariables } from "helpers/Constants";
 import {
   AppBar,
   Box,
@@ -41,7 +42,7 @@ export function NavBar(navBarProps: NavBarProps) {
     >
       <AppBar
         position="static"
-        style={{ backgroundColor: "var(--background-modifier-box-shadow)" }}
+        style={{ color: StyleVariables.TEXT_MUTED, backgroundColor: StyleVariables.BACKGROUND_SECONDARY, boxShadow: "none" }}
       >
         <Toolbar>
           <IconButton

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -229,6 +229,7 @@ export function Table(initialState: TableDataType) {
             position: "sticky",
             top: 0,
             zIndex: 1,
+            borderTop: "1px solid var(--background-modifier-border)",
           }}
         >
           <HeaderNavBar

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -310,14 +310,13 @@ export function Table(initialState: TableDataType) {
                           const tableCellProps = isDragUpdate
                             ? tableCellBaseProps
                             : {
-                                ...tableCellBaseProps,
-                                style: {
-                                  ...column.getHeaderProps().style,
-                                  width: `${
-                                    columnsWidthState.widthRecord[column.id]
+                              ...tableCellBaseProps,
+                              style: {
+                                ...column.getHeaderProps().style,
+                                width: `${columnsWidthState.widthRecord[column.id]
                                   }px`,
-                                },
-                              };
+                              },
+                            };
 
                           return (
                             <div {...tableCellProps}>
@@ -360,12 +359,12 @@ export function Table(initialState: TableDataType) {
                   const tableCellProps = isDragUpdate
                     ? tableCellBaseProps
                     : {
-                        ...tableCellBaseProps,
-                        style: {
-                          ...tableCellBaseProps.style,
-                          width: columnsWidthState.widthRecord[cell.column.id],
-                        },
-                      };
+                      ...tableCellBaseProps,
+                      style: {
+                        ...tableCellBaseProps.style,
+                        width: columnsWidthState.widthRecord[cell.column.id],
+                      },
+                    };
                   return <div {...tableCellProps}>{cell.render("Cell")}</div>;
                 })}
               </div>
@@ -382,22 +381,18 @@ export function Table(initialState: TableDataType) {
                 placeholder="filename of new row"
               />
             </div>
-            <div className={`${c("td")}`}>
-              <div
-                onClick={() => {
-                  dataDispatch({
-                    type: ActionTypes.ADD_ROW,
-                    filename: inputNewRow,
-                  });
-                  setInputNewRow("");
-                  newRowRef.current.value = "";
-                }}
-              >
-                <span className="svg-icon svg-gray" style={{ marginRight: 4 }}>
-                  <PlusIcon />
-                </span>
-                New
-              </div>
+            <div className={`${c("td")}`} onClick={() => {
+              dataDispatch({
+                type: ActionTypes.ADD_ROW,
+                filename: inputNewRow,
+              });
+              setInputNewRow("");
+              newRowRef.current.value = "";
+            }}>
+              <span className="svg-icon svg-gray" style={{ marginRight: 4 }}>
+                <PlusIcon />
+              </span>
+              New
             </div>
           </div>
         </div>

--- a/src/components/portals/PopperSelectPortal.tsx
+++ b/src/components/portals/PopperSelectPortal.tsx
@@ -77,7 +77,7 @@ const PopperSelectPortal = (popperProps: PopperProps) => {
   }
 
   function getColor() {
-    let match = (column as any).options.find(
+    const match = (column as any).options.find(
       (option: { label: any }) => option.label === value.value
     );
     return (match && match.backgroundColor) || grey(200);
@@ -93,7 +93,7 @@ const PopperSelectPortal = (popperProps: PopperProps) => {
         {/* show selector if click on the current value */}
         {showSelect && (
           <div
-            className="shadow-5 border-radius-md"
+            className="menu"
             ref={setSelectPop}
             {...attributes.popper}
             style={{
@@ -177,9 +177,9 @@ const PopperSelectPortal = (popperProps: PopperProps) => {
       </div>
       {domReady
         ? ReactDOM.createPortal(
-            PortalSelect(),
-            document.getElementById("popper-container")
-          )
+          PortalSelect(),
+          document.getElementById("popper-container")
+        )
         : null}
     </>
   );

--- a/src/components/portals/PopperSelectPortal.tsx
+++ b/src/components/portals/PopperSelectPortal.tsx
@@ -129,7 +129,6 @@ const PopperSelectPortal = (popperProps: PopperProps) => {
                     marginTop: "0.5rem",
                     width: 120,
                     padding: "2px 4px",
-                    backgroundColor: grey(200),
                     borderRadius: 4,
                   }}
                 >

--- a/src/components/reducers/GlobalFilter.tsx
+++ b/src/components/reducers/GlobalFilter.tsx
@@ -30,12 +30,7 @@ export default function GlobalFilter(globalFilterProps: GlobalFilterProps) {
           onChange(e.target.value);
         }}
         placeholder={`${count} records...`}
-        style={{
-          fontSize: "1.1rem",
-          border: "0",
-          background: StyleVariables.BACKGROUND_PRIMARY,
-          color: StyleVariables.TEXT_NORMAL,
-        }}
+        type={"search"}
       />
     </span>
   );

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -116,6 +116,7 @@ export const StyleVariables = Object.freeze({
   BACKGROUND_SECONDARY: 'var(--background-secondary)',
   BACKGROUND_DIVIDER: 'var(--background-divider)',
   TEXT_FAINT: 'var(--text-faint)',
+  TEXT_MUTED: 'var(--text-muted)',
   TEXT_NORMAL: 'var(--text-normal)',
 });
 

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,10 @@
   color: var(--text-muted);
   cursor: pointer;
   text-align: left;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .database-plugin__tr:last-child .database-plugin__td {

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,11 @@
   color: var(--text-accent-hover);
 }
 
+.database-plugin__add-row .database-plugin__td {
+  border: none;
+  background-color: transparent;
+}
+
 .database-plugin__th {
   color: var(--text-faint);
   font-weight: 500;

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,16 @@
   outline: none;
 }
 
+
+.database-plugin__md_cell {
+  padding: 0.5rem;
+}
+
+.database-plugin__md_cell p {
+  display: inline;
+}
+
+
 .svg-icon-sm svg {
   position: relative;
   height: 1.25em;

--- a/styles.css
+++ b/styles.css
@@ -93,12 +93,6 @@
   outline: none;
 }
 
-.shadow-5 {
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.12),
-    0 4px 6px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.12),
-    0 16px 32px rgba(0, 0, 0, 0.12);
-}
-
 .svg-icon-sm svg {
   position: relative;
   height: 1.25em;
@@ -268,10 +262,6 @@
 
 .flex-wrap-wrap {
   flex-wrap: wrap;
-}
-
-.border-radius-md {
-  border-radius: 5px;
 }
 
 .menu.database-plugin__popper {

--- a/styles.css
+++ b/styles.css
@@ -170,7 +170,9 @@
   border: none;
   background-color: transparent;
   color: var(--text-muted);
+
   flex-direction: row;
+  align-items: center;
 }
 
 .database-plugin__th {

--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,7 @@
 
 .menu.database-plugin__popper {
   position: relative;
+  padding: 0;
 }
 
 .cursor-pointer {

--- a/styles.css
+++ b/styles.css
@@ -277,6 +277,10 @@
   border-radius: 5px;
 }
 
+.menu.database-plugin__popper {
+  position: relative;
+}
+
 .cursor-pointer {
   cursor: pointer;
 }

--- a/styles.css
+++ b/styles.css
@@ -215,7 +215,6 @@
 
 .database-plugin__table {
   border-spacing: 0;
-  border-top: 1px solid var(--background-modifier-border);
   border-bottom: 1px solid var(--background-modifier-border);
   display: "flex";
 }

--- a/styles.css
+++ b/styles.css
@@ -86,7 +86,7 @@
 }
 
 .data-input:hover {
-  background-color: var(--background-modifier-box-shadow);
+  background-color: var(--background-secondary);
 }
 
 .data-input:focus {

--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,7 @@
   border: none;
   background-color: transparent;
   color: var(--text-muted);
+  flex-direction: row;
 }
 
 .database-plugin__th {

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,10 @@
   stroke: var(--text-faint);
 }
 
+.sort-button .svg-text svg {
+  stroke: var(--text-muted);
+}
+
 .svg-180 svg {
   transform: rotate(180deg);
 }
@@ -137,20 +141,13 @@
 
 .sort-button {
   padding: 0.25rem 0.75rem;
+  margin: 0;
   width: 100%;
   background-color: transparent;
-  border: 0;
   font-size: 0.875rem;
-  color: var(--text-faint);
+  color: var(--text-muted);
   cursor: pointer;
   text-align: left;
-  display: flex;
-  align-items: center;
-}
-
-.sort-button:hover {
-  background-color: var(--background-modifier-box-shadow);
-  color: var(--text-normal);
 }
 
 .database-plugin__tr:last-child .database-plugin__td {

--- a/styles.css
+++ b/styles.css
@@ -37,7 +37,7 @@
 
 .svg-icon svg {
   position: relative;
-  vertical-align: bottom;
+  display: block;
   height: 1.5em;
   width: 1.5em;
 }

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,7 @@
 .database-plugin__add-row .database-plugin__td {
   border: none;
   background-color: transparent;
+  color: var(--text-muted);
 }
 
 .database-plugin__th {

--- a/styles.css
+++ b/styles.css
@@ -162,7 +162,7 @@
 }
 
 .database-plugin__add-row:hover {
-  background-color: var(--background-modifier-box-shadow);
+  background-color: var(--background-secondary);
   color: var(--text-accent-hover);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
 .database-plugin__html {
   box-sizing: border-box;
 }
@@ -36,6 +37,7 @@
 
 .svg-icon svg {
   position: relative;
+  vertical-align: bottom;
   height: 1.5em;
   width: 1.5em;
 }
@@ -78,6 +80,7 @@
   box-sizing: border-box;
   flex: 1 1 auto;
 }
+
 .data-input:hover {
   background-color: var(--background-modifier-box-shadow);
 }
@@ -230,12 +233,9 @@
   position: relative;
 }
 
-.database-plugin__header-group ,
-.database-plugin__header{
-  display: flex;
-  align-items: center;
+.database-plugin__header-group,
+.database-plugin__header {
   justify-content: space-between;
-  padding: 0.5rem;
   background-color: var(--background-secondary);
 }
 


### PR DESCRIPTION
This PR improves some of the css styling. It fixes misaligned icons, the gap after the headings causing misaligned columns, invisible text, etc. It also changes the popovers to use the `menu` css class in obsidian, so that they get styled by themes.

Here's what the plugin looks like before:
![before](https://user-images.githubusercontent.com/100622574/167312509-49c1bab3-e0e3-447c-8214-f4f57254b5b9.png)

and after:
![after](https://user-images.githubusercontent.com/100622574/167312460-2dbe5e07-ac3d-41a8-89fc-e21b0783a091.png)

It also works well with all other themes I tested:
![minimal-after](https://user-images.githubusercontent.com/100622574/167312532-3aa63c95-1d43-4425-a6fc-65f4dfebfba2.png)

I'm not familiar with react, so let me know if I made any bad choices!

