### PR TITLE
Visual improvements

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -2,6 +2,7 @@ import { ColorPickerProps } from "cdm/StyleModel";
 import React from "react";
 import { ColorResult, SketchPicker } from "react-color";
 import { castHslToString } from "components/styles/ColumnWidthStyle";
+import { c } from "helpers/StylesHelper";
 
 export function ColorPicker(colorPickerProps: ColorPickerProps) {
   const { view, options, option, columnKey } = colorPickerProps;
@@ -31,9 +32,9 @@ export function ColorPicker(colorPickerProps: ColorPickerProps) {
   return (
     <>
       <span
-        className="colorPicker"
+        className={"colorPicker " + c("relationship")}
         onClick={() => setShowColorPicker(!showColorPicker)}
-        style={{ backgroundColor: colorState, padding: "5px" }}
+        style={{ backgroundColor: colorState }}
       >
         {option.label}
       </span>

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -296,7 +296,7 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
     columnWidthState.widthRecord[newKey] = getColumnWidthStyle(rows, column);
 
     /*
-      To adjust column settings to the new key, we need to update the order 
+      To adjust column settings to the new key, we need to update the order
       of the columns with it and calculate the new width
      */
     delete columnWidthState.widthRecord[column.id];
@@ -435,7 +435,9 @@ const HeaderMenu = (headerMenuProps: HeaderMenuProps) => {
                             <span className="svg-icon svg-text icon-margin">
                               {type.icon}
                             </span>
-                            {type.label}
+                            <span style={{ textTransform: "capitalize" }}>
+                              {type.label}
+                            </span>
                           </div>
                         </div>
                       ))}

--- a/src/components/RelationShip.tsx
+++ b/src/components/RelationShip.tsx
@@ -9,8 +9,7 @@ export default function Relationship(relationShipProps: RelationshipProps) {
     <span
       className={c("relationship")}
       style={{
-        backgroundColor: backgroundColor,
-        color: grey(800),
+        backgroundColor: backgroundColor
       }}
     >
       {value}

--- a/src/components/img/AdjustmentsIcon.tsx
+++ b/src/components/img/AdjustmentsIcon.tsx
@@ -6,7 +6,7 @@ export default function AdjustmentsIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/CalendarIcon.tsx
+++ b/src/components/img/CalendarIcon.tsx
@@ -6,7 +6,7 @@ export default function CalendarIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/CalendarTime.tsx
+++ b/src/components/img/CalendarTime.tsx
@@ -6,7 +6,7 @@ export default function CalendarTimeIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/CrossIcon.tsx
+++ b/src/components/img/CrossIcon.tsx
@@ -6,7 +6,7 @@ export default function CrossIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/DownloadIcon.tsx
+++ b/src/components/img/DownloadIcon.tsx
@@ -6,7 +6,7 @@ export default function DownloadIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/MenuIcon.tsx
+++ b/src/components/img/MenuIcon.tsx
@@ -6,7 +6,7 @@ export default function MarkdownObsidian() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/components/img/TaskIcon.tsx
+++ b/src/components/img/TaskIcon.tsx
@@ -6,7 +6,7 @@ export default function TaskIcon() {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      strokeWidth="2"
+      strokeWidth="1.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/styles.css
+++ b/styles.css
@@ -325,10 +325,11 @@
 }
 
 .database-plugin__relationship {
+  color: rgb(66, 66, 66);
   box-sizing: border-box;
   font-weight: 400;
   padding: 2px 6px;
-  border-radius: 4;
+  border-radius: 4px;
   display: inline-block;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
 .database-plugin__html {
   box-sizing: border-box;
 }
@@ -130,6 +131,7 @@
   display: grid;
   place-content: center;
 }
+
 .data-input-checkbox input[type="checkbox"]::before {
   content: "";
   width: 0.65em;
@@ -424,14 +426,10 @@
   width: 0;
 }
 
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::before,
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::before,
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::after,
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::before,
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before,
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::after,
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::after {
   box-sizing: content-box;
   position: absolute;
   border: 8px solid transparent;
@@ -443,10 +441,8 @@
   left: -8px;
 }
 
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::before,
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::before {
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::before,
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
   border-bottom-color: var(--background-modifier-border);
 }
 
@@ -455,21 +451,17 @@
   margin-top: -8px;
 }
 
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::before,
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before,
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::after {
   border-top: none;
   border-bottom-color: var(--background-modifier-border);
 }
 
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::after {
   top: 0;
 }
 
-.react-datepicker-popper[data-placement^="bottom"]
-  .react-datepicker__triangle::before {
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
   top: -1px;
   border-bottom-color: var(--background-modifier-border);
 }
@@ -479,21 +471,17 @@
   margin-bottom: -8px;
 }
 
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::before,
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::before,
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::after {
   border-bottom: none;
   border-top-color: #fff;
 }
 
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::after {
   bottom: 0;
 }
 
-.react-datepicker-popper[data-placement^="top"]
-  .react-datepicker__triangle::before {
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle::before {
   bottom: -1px;
   border-top-color: #aeaeae;
 }
@@ -559,8 +547,7 @@
   padding-top: 10px;
 }
 
-.react-datepicker-popper[data-placement="bottom-end"]
-  .react-datepicker__triangle,
+.react-datepicker-popper[data-placement="bottom-end"] .react-datepicker__triangle,
 .react-datepicker-popper[data-placement="top-end"] .react-datepicker__triangle {
   left: auto;
   right: 50px;
@@ -756,47 +743,30 @@
   display: inline-block;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container {
+.react-datepicker__input-time-container .react-datepicker-time__input-container {
   display: inline-block;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__input {
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input {
   display: inline-block;
   margin-left: 10px;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__input
-  input {
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input {
   width: auto;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__input
-  input[type="time"]::-webkit-inner-spin-button,
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__input
-  input[type="time"]::-webkit-outer-spin-button {
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"]::-webkit-inner-spin-button,
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__input
-  input[type="time"] {
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"] {
   -moz-appearance: textfield;
 }
 
-.react-datepicker__input-time-container
-  .react-datepicker-time__input-container
-  .react-datepicker-time__delimiter {
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__delimiter {
   margin-left: 5px;
   display: inline-block;
 }
@@ -822,9 +792,7 @@
   border-bottom-right-radius: 0.3rem;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box {
   width: 85px;
   overflow-x: hidden;
   margin: 0 auto;
@@ -832,10 +800,7 @@
   border-bottom-right-radius: 0.3rem;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list {
   list-style: none;
   margin: 0;
   height: calc(195px + (1.7rem / 2));
@@ -846,57 +811,33 @@
   box-sizing: content-box;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item {
   height: 30px;
   padding: 5px 10px;
   color: var(--text-normal);
   white-space: nowrap;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item:hover {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item:hover {
   cursor: pointer;
   background-color: #f0f0f0;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item--selected {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item--selected {
   background-color: #216ba5;
   color: var(--text-normal);
   font-weight: bold;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item--selected:hover {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item--selected:hover {
   background-color: #216ba5;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item--disabled {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item--disabled {
   color: #ccc;
 }
 
-.react-datepicker__time-container
-  .react-datepicker__time
-  .react-datepicker__time-box
-  ul.react-datepicker__time-list
-  li.react-datepicker__time-list-item--disabled:hover {
+.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item--disabled:hover {
   cursor: default;
   background-color: transparent;
 }
@@ -1078,14 +1019,10 @@
   background-color: rgba(33, 107, 165, 0.5);
 }
 
-.react-datepicker__month--selecting-range
-  .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
-.react-datepicker__month--selecting-range
-  .react-datepicker__month-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
-.react-datepicker__month--selecting-range
-  .react-datepicker__quarter-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
-.react-datepicker__month--selecting-range
-  .react-datepicker__year-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range) {
+.react-datepicker__month--selecting-range .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
+.react-datepicker__month--selecting-range .react-datepicker__month-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
+.react-datepicker__month--selecting-range .react-datepicker__quarter-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range),
+.react-datepicker__month--selecting-range .react-datepicker__year-text--in-range:not(.react-datepicker__day--in-selecting-range, .react-datepicker__month-text--in-selecting-range, .react-datepicker__quarter-text--in-selecting-range, .react-datepicker__year-text--in-selecting-range) {
   background-color: #f0f0f0;
   color: var(--text-normal);
 }
@@ -1141,18 +1078,12 @@
   cursor: pointer;
 }
 
-.react-datepicker__year-read-view:hover
-  .react-datepicker__year-read-view--down-arrow,
-.react-datepicker__year-read-view:hover
-  .react-datepicker__month-read-view--down-arrow,
-.react-datepicker__month-read-view:hover
-  .react-datepicker__year-read-view--down-arrow,
-.react-datepicker__month-read-view:hover
-  .react-datepicker__month-read-view--down-arrow,
-.react-datepicker__month-year-read-view:hover
-  .react-datepicker__year-read-view--down-arrow,
-.react-datepicker__month-year-read-view:hover
-  .react-datepicker__month-read-view--down-arrow {
+.react-datepicker__year-read-view:hover .react-datepicker__year-read-view--down-arrow,
+.react-datepicker__year-read-view:hover .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-read-view:hover .react-datepicker__year-read-view--down-arrow,
+.react-datepicker__month-read-view:hover .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view:hover .react-datepicker__year-read-view--down-arrow,
+.react-datepicker__month-year-read-view:hover .react-datepicker__month-read-view--down-arrow {
   border-top-color: #b3b3b3;
 }
 
@@ -1225,21 +1156,15 @@
   background-color: var(--interactive-success);
 }
 
-.react-datepicker__year-option:hover
-  .react-datepicker__navigation--years-upcoming,
-.react-datepicker__month-option:hover
-  .react-datepicker__navigation--years-upcoming,
-.react-datepicker__month-year-option:hover
-  .react-datepicker__navigation--years-upcoming {
+.react-datepicker__year-option:hover .react-datepicker__navigation--years-upcoming,
+.react-datepicker__month-option:hover .react-datepicker__navigation--years-upcoming,
+.react-datepicker__month-year-option:hover .react-datepicker__navigation--years-upcoming {
   border-bottom-color: var(--interactive-success);
 }
 
-.react-datepicker__year-option:hover
-  .react-datepicker__navigation--years-previous,
-.react-datepicker__month-option:hover
-  .react-datepicker__navigation--years-previous,
-.react-datepicker__month-year-option:hover
-  .react-datepicker__navigation--years-previous {
+.react-datepicker__year-option:hover .react-datepicker__navigation--years-previous,
+.react-datepicker__month-option:hover .react-datepicker__navigation--years-previous,
+.react-datepicker__month-year-option:hover .react-datepicker__navigation--years-previous {
   border-top-color: var(--interactive-success);
 }
 
@@ -1310,7 +1235,9 @@
   line-height: 3rem;
 }
 
-@media (max-width: 400px), (max-height: 550px) {
+@media (max-width: 400px),
+(max-height: 550px) {
+
   .react-datepicker__portal .react-datepicker__day-name,
   .react-datepicker__portal .react-datepicker__day,
   .react-datepicker__portal .react-datepicker__time-name {

--- a/styles.css
+++ b/styles.css
@@ -496,7 +496,6 @@
 .react-datepicker-wrapper input[type="text"],
 .react-datepicker-wrapper input[type="text"]:focus {
   border: none;
-  font-family: "Inter", sans-serif;
   font-size: var(--font-size-normal);
   padding: 0.5rem;
   color: var(--text-normal);

--- a/styles.css
+++ b/styles.css
@@ -513,8 +513,8 @@
 .react-datepicker {
   font-size: 0.8rem;
   background-color: var(--background-primary);
-  color: var(--background-primary-alt);
-  border: 1px solid var(--background-secondary);
+  color: var(--text-normal);
+  border: 1px solid var(--background-modifier-border);
   border-radius: 0.3rem;
   display: inline-block;
   position: relative;


### PR DESCRIPTION
This PR makes some minor visual improvements.

- Fixes unreadable text in dark mode
![image](https://user-images.githubusercontent.com/100622574/172048331-03265ebf-d1ba-4443-91fa-577bede24143.png)
![image](https://user-images.githubusercontent.com/100622574/172048358-543a1f8b-a80b-4d3d-b6af-515812248f49.png)

- Capitalise property labels, and give all svg icons the same line width (1.5)
![image](https://user-images.githubusercontent.com/100622574/172048392-2f002230-1c58-408e-a9a1-65de517f4ac6.png)
![image](https://user-images.githubusercontent.com/100622574/172048381-81c404d7-9701-48b0-83c4-8eaf03d1cb45.png)

- Make datetime cells use the same font as the rest of the UI
![image](https://user-images.githubusercontent.com/100622574/172048575-4e458586-2286-4ee8-86aa-81484d5726ba.png)

![image](https://user-images.githubusercontent.com/100622574/172048563-07c3b9f2-69cf-45b2-a4f8-c1a666e6e47c.png)
