### PR TITLE
Add ability to change cell size

### DIFF
--- a/TestVault/template/database.md
+++ b/TestVault/template/database.md
@@ -110,12 +110,13 @@ columns:
       source_data: current_folder
 config:
   enable_show_state: false
-  group_folder_column: 
+  group_folder_column:
   remove_field_when_delete_column: true
+  cell_size: normal
   show_metadata_created: true
   show_metadata_modified: true
   source_data: current_folder
-  source_form_result: 
+  source_form_result:
   show_metadata_tasks: true
 filters:
 %%>

--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -8,7 +8,7 @@ Details about your database
 - **name**: Name asociated to your database.
 - **description**: extra information explaining the purpose of the database. Will be displated in preview mode.
 ### Database
-The *columns* key is used to charge the correct information when you charge the react-table. Each column supports all the literals of react-table column configurations. 
+The *columns* key is used to charge the correct information when you charge the react-table. Each column supports all the literals of react-table column configurations.
 
 Mandatory:
 
@@ -158,6 +158,7 @@ columns:
 config:
   enable_show_state: false
   group_folder_column: none
+  cell_size: normal
   remove_field_when_delete_column: true
   show_metadata_created: false
   show_metadata_modified: false

--- a/src/DatabaseView.tsx
+++ b/src/DatabaseView.tsx
@@ -145,6 +145,7 @@ export class DatabaseView extends TextFileView implements HoverParent {
         view: this,
         stateManager: this.plugin.getStateManager(this.file),
         initialState: initialState,
+        cellSize: this.diskConfig.yaml.config.cell_size
       };
 
       // Render database

--- a/src/cdm/FolderModel.ts
+++ b/src/cdm/FolderModel.ts
@@ -88,6 +88,7 @@ export type TableDataType = {
     stateManager: StateManager,
     dispatch?: Dispatch<any>,
     initialState?: InitialState,
+    cellSize: string
 }
 export interface DatabaseHeaderProps {
     columns: any,

--- a/src/cdm/SettingsModel.ts
+++ b/src/cdm/SettingsModel.ts
@@ -14,6 +14,7 @@ interface GlobalSettings {
 export interface LocalSettings {
     enable_show_state: boolean;
     group_folder_column: string;
+    cell_size: string;
     remove_field_when_delete_column: boolean;
     show_metadata_created: boolean;
     show_metadata_modified: boolean;

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -239,7 +239,7 @@ export function Table(initialState: TableDataType) {
             width: totalWidth,
           },
         })}
-        className={`${c("table noselect")}`}
+        className={`${c("table noselect cell_size_" + initialState.cellSize)}`}
         onMouseOver={onMouseOver}
         onClick={onClick}
       >
@@ -341,9 +341,8 @@ export function Table(initialState: TableDataType) {
                                 ...provided.dragHandleProps,
                                 ...column.getHeaderProps({
                                   style: {
-                                    width: `${
-                                      columnsWidthState.widthRecord[column.id]
-                                    }px`,
+                                    width: `${columnsWidthState.widthRecord[column.id]
+                                      }px`,
                                     ...getDndItemStyle(
                                       snapshot.isDragging,
                                       provided.draggableProps.style

--- a/src/components/portals/CalendarTimePortal.tsx
+++ b/src/components/portals/CalendarTimePortal.tsx
@@ -49,11 +49,11 @@ const CalendarTimePortal = (calendarProps: CalendarProps) => {
   };
 
   return column.isMetadata ? (
-    <span className="data-input calendar-time">
+    <span className="calendar-time">
       {(contextValue.value as DateTime).toFormat("yyyy-MM-dd h:mm a")}
     </span>
   ) : (
-    <div className="data-input calendar-time">
+    <div className="calendar-time">
       <DatePicker
         dateFormat="yyyy-MM-dd h:mm aa"
         selected={calendarState}

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -196,6 +196,14 @@ export const SourceDataTypes = Object.freeze({
   INCOMING_LINK: 'incoming_link',
 });
 
+
+export const CellSizeOptions = Object.freeze({
+  COMPACT: 'compact',
+  NORMAL: 'normal',
+  WIDE: 'wide'
+})
+
+
 export const WidthVariables = Object.freeze({
   ICON_SPACING: 17,
   MAGIC_SPACING: 10
@@ -244,6 +252,7 @@ export const DEFAULT_SETTINGS: DatabaseSettings = {
   local_settings: {
     enable_show_state: false,
     remove_field_when_delete_column: false,
+    cell_size: CellSizeOptions.NORMAL,
     group_folder_column: '',
     show_metadata_created: false,
     show_metadata_modified: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ export default class DBFolderPlugin extends Plugin {
 
 	viewMap: Map<string, DatabaseView> = new Map();
 
-	_loaded: boolean = false;
+	_loaded = false;
 
 	stateManagers: Map<TFile, StateManager> = new Map();
 
@@ -108,7 +108,7 @@ export default class DBFolderPlugin extends Plugin {
 		priority: number,
 		processor: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>
 	) {
-		let registered = this.registerMarkdownCodeBlockProcessor(language, processor);
+		const registered = this.registerMarkdownCodeBlockProcessor(language, processor);
 		registered.sortOrder = priority;
 	}
 
@@ -164,7 +164,7 @@ export default class DBFolderPlugin extends Plugin {
 		}
 	}
 
-	async setMarkdownView(leaf: WorkspaceLeaf, focus: boolean = true) {
+	async setMarkdownView(leaf: WorkspaceLeaf, focus = true) {
 		await leaf.setViewState(
 			{
 				type: 'markdown',
@@ -220,6 +220,7 @@ export default class DBFolderPlugin extends Plugin {
 			` enable_show_state: ${local_settings.enable_show_state}`,
 			` group_folder_column: `,
 			` remove_field_when_delete_column: ${local_settings.remove_field_when_delete_column}`,
+			` cell_size: ${local_settings.cell_size}`,
 			` show_metadata_created: ${local_settings.show_metadata_created}`,
 			` show_metadata_modified: ${local_settings.show_metadata_modified}`,
 			` source_data: ${local_settings.source_data}`,

--- a/src/parsers/handlers/marshall/MarshallConfigHandler.ts
+++ b/src/parsers/handlers/marshall/MarshallConfigHandler.ts
@@ -1,9 +1,9 @@
 import { YamlHandlerResponse } from 'cdm/MashallModel';
-import { SourceDataTypes } from 'helpers/Constants';
+import { SourceDataTypes, CellSizeOptions } from 'helpers/Constants';
 import { AbstractYamlHandler } from 'parsers/handlers/marshall/AbstractYamlPropertyHandler';
 
 export class MarshallConfigHandler extends AbstractYamlHandler {
-    handlerName: string = 'configuration';
+    handlerName = 'configuration';
 
     public handle(handlerResponse: YamlHandlerResponse): YamlHandlerResponse {
         const { yaml } = handlerResponse;
@@ -24,6 +24,12 @@ export class MarshallConfigHandler extends AbstractYamlHandler {
             if (checkNullable(yaml.config.remove_field_when_delete_column)) {
                 this.addError(`There was not remove_field_when_delete_column key in yaml. Default will be loaded`);
                 yaml.config.remove_field_when_delete_column = false;
+            }
+
+            // if cell_size is not defined, load default
+            if (checkNullable(yaml.config.cell_size)) {
+                this.addError(`There was not cell_size key in yaml. Default will be loaded`);
+                yaml.config.cell_size = CellSizeOptions.NORMAL;
             }
 
             // if show_metadata_created is not defined, load default

--- a/src/settings/FolderSection.ts
+++ b/src/settings/FolderSection.ts
@@ -1,6 +1,7 @@
 import { add_setting_header } from 'settings/SettingsComponents';
 import { SettingHandler, SettingHandlerResponse } from 'settings/handlers/AbstractSettingHandler';
 import { FilterDataviewHandler } from './handlers/folder/FilterDataviewHandler';
+import { CellSizeDropDownHandler } from './handlers/folder/CellSizeDropDownHandler';
 import { DetailsFormHandler } from './handlers/folder/DetailsFormHandler';
 
 /**
@@ -28,6 +29,7 @@ export function folder_settings_section(settingHandlerResponse: SettingHandlerRe
 function getHandlers(): SettingHandler[] {
     return [
         new DetailsFormHandler(),
+        new CellSizeDropDownHandler(),
         new FilterDataviewHandler(),
     ];
 }

--- a/src/settings/handlers/folder/CellSizeDropDownHandler.ts
+++ b/src/settings/handlers/folder/CellSizeDropDownHandler.ts
@@ -1,0 +1,30 @@
+import { CellSizeOptions } from "helpers/Constants";
+import { AbstractSettingsHandler, SettingHandlerResponse } from "settings/handlers/AbstractSettingHandler";
+import { add_dropdown } from "settings/SettingsComponents";
+
+export class CellSizeDropDownHandler extends AbstractSettingsHandler {
+    settingTitle = 'Cell size';
+    handle(settingHandlerResponse: SettingHandlerResponse): SettingHandlerResponse {
+        const { settingsManager, containerEl, view } = settingHandlerResponse;
+        const source_dropdown_promise = async (value: string): Promise<void> => {
+            // update settings
+            view.diskConfig.updateConfig('cell_size', value);
+            // Force refresh of settings
+            settingsManager.reset(settingHandlerResponse);
+        };
+        // render dropdown inside container
+        add_dropdown(
+            containerEl,
+            this.settingTitle,
+            'Choose how compact or wide cells are.',
+            view.diskConfig.yaml.config.cell_size,
+            {
+                compact: CellSizeOptions.COMPACT,
+                normal: CellSizeOptions.NORMAL,
+                wide: CellSizeOptions.WIDE
+            },
+            source_dropdown_promise
+        );
+        return this.goNext(settingHandlerResponse);
+    }
+}

--- a/src/settings/handlers/folder/CellSizeDropDownHandler.ts
+++ b/src/settings/handlers/folder/CellSizeDropDownHandler.ts
@@ -9,8 +9,6 @@ export class CellSizeDropDownHandler extends AbstractSettingsHandler {
         const source_dropdown_promise = async (value: string): Promise<void> => {
             // update settings
             view.diskConfig.updateConfig('cell_size', value);
-            // Force refresh of settings
-            settingsManager.reset(settingHandlerResponse);
         };
         // render dropdown inside container
         add_dropdown(

--- a/styles.css
+++ b/styles.css
@@ -284,6 +284,23 @@
   align-items: center;
 }
 
+
+.database-plugin__cell_size_compact .database-plugin__td {
+  padding: 0;
+}
+
+
+.database-plugin__cell_size_normal .database-plugin__td {
+  padding: 0.3rem;
+}
+
+
+.database-plugin__cell_size_wide .database-plugin__td {
+  padding: 0.6rem;
+}
+
+
+
 .database-plugin__table {
   border-spacing: 0;
   border-bottom: 1px solid var(--background-modifier-border);


### PR DESCRIPTION
This PR adds the ability to change the size of cells (#69).

It adds a dropdown in the database settings to change the cell size:
![image](https://user-images.githubusercontent.com/100622574/172048669-ab0a60a4-14c9-4cf4-a03c-7ad961b7b9d8.png)

The setting is stored in the database config as `cell_size`:
![image](https://user-images.githubusercontent.com/100622574/172048715-d2332782-db28-469a-953e-d4a5c41593de.png)

Then, depending on the setting, a css class is added to the Table (`database-plugin__cell_size_compact`, `database-plugin__cell_size_normal`, or `database-plugin__cell_size_wide`). The amount of padding in each cell is adjusted based on css.

Here are the three options (compact, normal and wide):
![image](https://user-images.githubusercontent.com/100622574/172048784-830ba06d-0dda-4739-9f95-3b8464090083.png)
![image](https://user-images.githubusercontent.com/100622574/172048798-369a804a-ab2e-43bc-a6d2-b75f87d1d880.png)
![image](https://user-images.githubusercontent.com/100622574/172048815-08280c2f-63f7-47aa-856d-e98ae8e95df7.png)
