### PR TITLE
Add ability to make first column sticky

### DIFF
--- a/TestVault/template/database.md
+++ b/TestVault/template/database.md
@@ -113,6 +113,7 @@ config:
   group_folder_column:
   remove_field_when_delete_column: true
   cell_size: normal
+  sticky_first_column: false
   show_metadata_created: true
   show_metadata_modified: true
   source_data: current_folder

--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -159,6 +159,7 @@ config:
   enable_show_state: false
   group_folder_column: none
   cell_size: normal
+  sticky_first_column: false
   remove_field_when_delete_column: true
   show_metadata_created: false
   show_metadata_modified: false

--- a/src/DatabaseView.tsx
+++ b/src/DatabaseView.tsx
@@ -145,7 +145,8 @@ export class DatabaseView extends TextFileView implements HoverParent {
         view: this,
         stateManager: this.plugin.getStateManager(this.file),
         initialState: initialState,
-        cellSize: this.diskConfig.yaml.config.cell_size
+        cellSize: this.diskConfig.yaml.config.cell_size,
+        stickyFirstColumn: this.diskConfig.yaml.config.sticky_first_column
       };
 
       // Render database

--- a/src/cdm/FolderModel.ts
+++ b/src/cdm/FolderModel.ts
@@ -88,7 +88,8 @@ export type TableDataType = {
     stateManager: StateManager,
     dispatch?: Dispatch<any>,
     initialState?: InitialState,
-    cellSize: string
+    cellSize: string,
+    stickyFirstColumn: boolean
 }
 export interface DatabaseHeaderProps {
     columns: any,

--- a/src/cdm/SettingsModel.ts
+++ b/src/cdm/SettingsModel.ts
@@ -15,6 +15,7 @@ export interface LocalSettings {
     enable_show_state: boolean;
     group_folder_column: string;
     cell_size: string;
+    sticky_first_column: boolean;
     remove_field_when_delete_column: boolean;
     show_metadata_created: boolean;
     show_metadata_modified: boolean;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -42,7 +42,7 @@ export function NavBar(navBarProps: NavBarProps) {
     >
       <AppBar
         position="static"
-        style={{ color: StyleVariables.TEXT_MUTED, backgroundColor: StyleVariables.BACKGROUND_SECONDARY, boxShadow: "none", position: "fixed", left: 0 }}
+        style={{ color: StyleVariables.TEXT_MUTED, backgroundColor: StyleVariables.BACKGROUND_SECONDARY, boxShadow: "none", position: "fixed", left: 0, width: "calc(100% - 20px)" }}
       >
         <Toolbar>
           <IconButton

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -42,7 +42,7 @@ export function NavBar(navBarProps: NavBarProps) {
     >
       <AppBar
         position="static"
-        style={{ color: StyleVariables.TEXT_MUTED, backgroundColor: StyleVariables.BACKGROUND_SECONDARY, boxShadow: "none" }}
+        style={{ color: StyleVariables.TEXT_MUTED, backgroundColor: StyleVariables.BACKGROUND_SECONDARY, boxShadow: "none", position: "fixed", left: 0 }}
       >
         <Toolbar>
           <IconButton
@@ -73,6 +73,7 @@ export function NavBar(navBarProps: NavBarProps) {
           <GlobalFilter {...navBarProps.globalFilterRows} />
         </Toolbar>
       </AppBar>
+      <Toolbar />
     </Box>
   );
 }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -239,7 +239,7 @@ export function Table(initialState: TableDataType) {
             width: totalWidth,
           },
         })}
-        className={`${c("table noselect cell_size_" + initialState.cellSize)}`}
+        className={`${c("table noselect cell_size_" + initialState.cellSize + (initialState.stickyFirstColumn ? " sticky_first_column" : ""))}`}
         onMouseOver={onMouseOver}
         onClick={onClick}
       >
@@ -247,7 +247,7 @@ export function Table(initialState: TableDataType) {
           style={{
             position: "sticky",
             top: 0,
-            zIndex: 1,
+            zIndex: 2,
             borderTop: "1px solid var(--background-modifier-border)",
           }}
         >
@@ -432,12 +432,12 @@ export function Table(initialState: TableDataType) {
                 onKeyDown={handleKeyDown}
                 placeholder="filename of new row"
               />
-            </div>
-            <div className={`${c("td")}`} onClick={handleAddNewRow}>
-              <span className="svg-icon svg-gray" style={{ marginRight: 4 }}>
-                <PlusIcon />
-              </span>
-              New
+              <div className={`${c("td")}`} onClick={handleAddNewRow}>
+                <span className="svg-icon svg-gray" style={{ marginRight: 4 }}>
+                  <PlusIcon />
+                </span>
+                New
+              </div>
             </div>
           </div>
         </div>

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -253,6 +253,7 @@ export const DEFAULT_SETTINGS: DatabaseSettings = {
     enable_show_state: false,
     remove_field_when_delete_column: false,
     cell_size: CellSizeOptions.NORMAL,
+    sticky_first_column: false,
     group_folder_column: '',
     show_metadata_created: false,
     show_metadata_modified: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,6 +221,7 @@ export default class DBFolderPlugin extends Plugin {
 			` group_folder_column: `,
 			` remove_field_when_delete_column: ${local_settings.remove_field_when_delete_column}`,
 			` cell_size: ${local_settings.cell_size}`,
+			` sticky_first_column: ${local_settings.sticky_first_column}`,
 			` show_metadata_created: ${local_settings.show_metadata_created}`,
 			` show_metadata_modified: ${local_settings.show_metadata_modified}`,
 			` source_data: ${local_settings.source_data}`,

--- a/src/parsers/handlers/marshall/MarshallConfigHandler.ts
+++ b/src/parsers/handlers/marshall/MarshallConfigHandler.ts
@@ -32,6 +32,12 @@ export class MarshallConfigHandler extends AbstractYamlHandler {
                 yaml.config.cell_size = CellSizeOptions.NORMAL;
             }
 
+            // if sticky_first_column is not defined, load default
+            if (checkNullable(yaml.config.sticky_first_column)) {
+                this.addError(`There was not sticky_first_column key in yaml. Default will be loaded`);
+                yaml.config.sticky_first_column = false;
+            }
+
             // if show_metadata_created is not defined, load default
             if (checkNullable(yaml.config.show_metadata_created)) {
                 this.addError(`There was not show_metadata_created key in yaml. Default will be loaded`);

--- a/src/settings/FolderSection.ts
+++ b/src/settings/FolderSection.ts
@@ -2,6 +2,7 @@ import { add_setting_header } from 'settings/SettingsComponents';
 import { SettingHandler, SettingHandlerResponse } from 'settings/handlers/AbstractSettingHandler';
 import { FilterDataviewHandler } from './handlers/folder/FilterDataviewHandler';
 import { CellSizeDropDownHandler } from './handlers/folder/CellSizeDropDownHandler';
+import { StickyFirstColumnHandler } from './handlers/folder/StickyFirstColumnHandler';
 import { DetailsFormHandler } from './handlers/folder/DetailsFormHandler';
 
 /**
@@ -30,6 +31,7 @@ function getHandlers(): SettingHandler[] {
     return [
         new DetailsFormHandler(),
         new CellSizeDropDownHandler(),
+        new StickyFirstColumnHandler(),
         new FilterDataviewHandler(),
     ];
 }

--- a/src/settings/handlers/folder/StickyFirstColumnHandler.ts
+++ b/src/settings/handlers/folder/StickyFirstColumnHandler.ts
@@ -1,0 +1,23 @@
+import { AbstractSettingsHandler, SettingHandlerResponse } from "settings/handlers/AbstractSettingHandler";
+import { add_toggle } from "settings/SettingsComponents";
+
+export class StickyFirstColumnHandler extends AbstractSettingsHandler {
+    settingTitle = 'Sticky first column';
+    handle(settingHandlerResponse: SettingHandlerResponse): SettingHandlerResponse {
+        const { settingsManager, containerEl, view } = settingHandlerResponse;
+        const sticky_first_column_toggle_promise = async (value: boolean): Promise<void> => {
+            // update settings
+            view.diskConfig.updateConfig('sticky_first_column', value);
+        };
+
+        add_toggle(
+            containerEl,
+            this.settingTitle,
+            "Whether to make the first column sticky, so that it remains visible when scrolling horizontally.",
+            view.diskConfig.yaml.config.sticky_first_column,
+            sticky_first_column_toggle_promise
+        );
+
+        return this.goNext(settingHandlerResponse);
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -343,6 +343,7 @@
 .database-plugin__navbar {
   display: flex;
   flex: 1 0 auto;
+  background-color: var(--background-secondary);
 }
 
 .database-plugin__calendar {

--- a/styles.css
+++ b/styles.css
@@ -302,6 +302,14 @@
 }
 
 
+.database-plugin__sticky_first_column .database-plugin__td:first-child,
+.database-plugin__sticky_first_column .database-plugin__th:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+
 
 .database-plugin__table {
   border-spacing: 0;


### PR DESCRIPTION
This PR ensures the search/navbar remains fixed when scrolling horizontally, and adds the ability to make the first column sticky (#51).

A 'sticky_first_column' setting is added in the database settings:
![image](https://user-images.githubusercontent.com/100622574/172157269-8e7e0efb-0ef6-453d-8e75-cc6ad44b565a.png)
![image](https://user-images.githubusercontent.com/100622574/172157325-4833554e-c789-4881-b21a-b5fe03cc6f96.png)

When switched on, the class `.database-plugin__sticky_first_column` is added to the Table. This adds 'position: sticky; left: 0' to the first cell in each row.

Demo:

https://user-images.githubusercontent.com/100622574/172158518-4981f405-c4fa-421c-b583-7d885b14c27b.mp4


