### PR TITLE
Patch to display correct checkbox state

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -18,9 +18,7 @@ export function CheckboxCell(props: CheckboxProps) {
   const note: NoteInfo = (cellProperties.row.original as any).__note__;
   /** state of cell value */
   const { contextValue, setContextValue } = useContext(CellContext);
-  const [checked, setChecked] = useState(
-    DataviewService.getDataviewAPI().value.isBoolean(contextValue.value)
-  );
+  const [checked, setChecked] = useState(contextValue.value);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.checked ? 1 : 0;
     // save on disk


### PR DESCRIPTION
Currently the checkbox will appear checked as long as the checkbox value is set in the file front matter, even if it 0. It can be easily reproduced by checking and unchecking a box, and then closing and reopening the database file:

![image](https://user-images.githubusercontent.com/40349712/178402618-bad28aaa-5eb5-478a-9a73-58745014fadb.png)

This fixes a bug in how the checkbox value is read.