### PR TITLE
Fix link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can add a folder database by right clicking on the folder where you want to 
 <img src="https://github.com/RafaelGB/obsidian-db-folder/blob/master/docs/resources/AddDatabase.gif" width="200" height="250"/>
 
 ### How to use?
-Database has its own type of view. It will search all notes into the same folder of the database and show the columns that you specify. Check our [documentation](https://rafaelgb.github.io/obsidian-db-folder/features/rows/) for more information.
+Database has its own type of view. It will search all notes into the same folder of the database and show the columns that you specify. Check our [documentation](https://rafaelgb.github.io/obsidian-db-folder/features/Columns/) for more information.
 
 The information you add or edit will be saved into the target obsidian note.
 


### PR DESCRIPTION
Hey!
I just noticed that one of the links in the README is broken. I believe the reference to the columns should link to the corresponding columns feature page in the documentation. This PR only changes that one link. 

It also seems like your GH Pages site has some weird left over styling for the non-existing "rows" page instead of the usual 404, so maybe you could look into that as well.
Cheers!