### PR TITLE
Add flex wrap to css class

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -503,6 +503,7 @@ div.database-plugin__checkbox {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .database-plugin__text-align-left {


### PR DESCRIPTION
Add flex wrap, to place the tags without overlapping.

![changerequestobsidiandbplugin](https://user-images.githubusercontent.com/39612138/192691257-c4239fab-35d1-42bd-bc46-780828584029.png)
