### PR TITLE
option to select binary checkbox states for integration with Tracker plugin

### DIFF
--- a/src/cdm/SettingsModel.ts
+++ b/src/cdm/SettingsModel.ts
@@ -34,6 +34,7 @@ export interface LocalSettings {
     show_metadata_inlinks: boolean;
     show_metadata_outlinks: boolean;
     show_metadata_tags: boolean;
+    binary_checkbox_type: boolean;
     source_form_result: string;
     source_destination_path: string;
     source_data: string;

--- a/src/components/cellTypes/CheckboxCell.tsx
+++ b/src/components/cellTypes/CheckboxCell.tsx
@@ -3,7 +3,8 @@ import { TableColumn } from "cdm/FolderModel";
 import { c } from "helpers/StylesHelper";
 import { CellComponentProps } from "cdm/ComponentsModel";
 import { ParseService } from "services/ParseService";
-import { InputType } from "helpers/Constants";
+import {DEFAULT_SETTINGS, InputType} from "helpers/Constants";
+import {Notice} from "obsidian";
 
 function CheckboxCell(props: CellComponentProps) {
   const { defaultCell } = props;
@@ -15,22 +16,23 @@ function CheckboxCell(props: CellComponentProps) {
   const checkboxRow = tableState.data((state) => state.rows[row.index]);
   const columnsInfo = tableState.columns((state) => state.info);
   const configInfo = tableState.configState((state) => state.info);
+  const isBinaryCellType = DEFAULT_SETTINGS.local_settings.binary_checkbox_type;
   const checkboxCell = tableState.data(
     (state) =>
       ParseService.parseRowToCell(
         state.rows[row.index],
         tableColumn,
-        InputType.CHECKBOX,
+          isBinaryCellType ? InputType.NUMBER : InputType.CHECKBOX,
         configInfo.getLocalSettings()
-      ) as boolean
+      ) as boolean | number
   );
 
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.checked;
-    editCheckbox(newValue);
+    editCheckbox( isBinaryCellType ? (newValue ? 1 : 0) : newValue );
   };
 
-  const editCheckbox = async (newValue: boolean) => {
+  const editCheckbox = async (newValue: boolean | number) => {
     const newCell = ParseService.parseRowToLiteral(
       checkboxRow,
       tableColumn,
@@ -55,13 +57,13 @@ function CheckboxCell(props: CellComponentProps) {
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          editCheckbox(!checkboxCell);
+          editCheckbox(isBinaryCellType ? (checkboxCell ? 1 : 0) : !checkboxCell);
         }
       }}
     >
       <input
         type="checkbox"
-        checked={checkboxCell}
+        checked={!!checkboxCell}
         key={`checkbox-input-${row.index}`}
         onChange={handleChange}
       />

--- a/src/components/modals/columnSettings/ColumnSections.ts
+++ b/src/components/modals/columnSettings/ColumnSections.ts
@@ -95,6 +95,7 @@ class BehaviorSetttingsSection extends AbstractChain<ColumnSettingsHandlerRespon
             case InputType.INLINKS:
             case InputType.OUTLINKS:
             case InputType.METADATA_TAGS:
+            case InputType.CHECKBOX_TYPE:
                 // do nothing
                 break;
             default:

--- a/src/components/modals/newColumn/handlers/MetadataToggleGroupHandler.ts
+++ b/src/components/modals/newColumn/handlers/MetadataToggleGroupHandler.ts
@@ -1,6 +1,6 @@
 import { AddColumnModalHandlerResponse } from "cdm/ModalsModel";
 import { ColumnSettingsModal } from "components/modals/columnSettings/ColumnSettingsModal";
-import { MetadataColumns } from "helpers/Constants";
+import {DEFAULT_SETTINGS, MetadataColumns} from "helpers/Constants";
 import { t } from "lang/helpers";
 import { Setting } from "obsidian";
 import { AbstractHandlerClass } from "patterns/chain/AbstractHandler";
@@ -131,6 +131,24 @@ export class MetadataToggleGroupHandler extends AbstractHandlerClass<AddColumnMo
             .addToggle(toggle =>
                 toggle.setValue(view.diskConfig.yaml.config.show_metadata_tags)
                     .onChange(metadata_tags_toggle_promise)
+            );
+
+        /************************
+         * CHECKBOX TYPE COLUMN
+         ************************/
+        const metadata_checkbox_type_toggle_promise = async (value: boolean): Promise<void> => {
+            // Persist value
+            view.diskConfig.updateConfig({ binary_checkbox_type: value });
+            addColumnModalManager.addColumnModal.enableReset = true;
+            DEFAULT_SETTINGS.local_settings.binary_checkbox_type = value;
+        }
+
+        new Setting(metadata_section)
+            .setName(t("settings_metatata_checkbox_type_toggle_title"))
+            .setDesc(t("settings_metatata_checkbox_type_toggle_desc"))
+            .addToggle(toggle =>
+                toggle.setValue(view.diskConfig.yaml.config.binary_checkbox_type)
+                    .onChange(metadata_checkbox_type_toggle_promise)
             );
 
         return this.goNext(response);

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -31,6 +31,7 @@ export const StaticInputType = Object.freeze({
   INLINKS: 'inlinks',
   OUTLINKS: 'outlinks',
   METADATA_TAGS: 'metadata_tags',
+  CHECKBOX_TYPE: 'checkbox_type',
   NEW_COLUMN: 'new_column',
 });
 
@@ -54,6 +55,7 @@ export const MetadataColumns = Object.freeze({
   INLINKS: `__inlinks__`,
   ROW_CONTEXT_MENU: "__rowContextMenu__",
   TAGS: `__tags__`,
+  CHECKBOX_TYPE: `__checkbox_type__`,
 });
 
 export const MetadataLabels = Object.freeze({
@@ -65,6 +67,7 @@ export const MetadataLabels = Object.freeze({
   OUTLINKS: 'Outlinks',
   INLINKS: 'Inlinks',
   TAGS: 'File Tags',
+  CHECKBOX_TYPE: 'Checkbox Type',
 });
 
 export const PaginationRenderOptions = Object.freeze({
@@ -223,6 +226,18 @@ export const MetadataDatabaseColumns: MetadataColumnsModel = Object.freeze({
     input: InputType.METADATA_TAGS,
     label: MetadataLabels.TAGS,
     accessorKey: MetadataColumns.TAGS,
+    isMetadata: true,
+    isDragDisabled: false,
+    skipPersist: false,
+    csvCandidate: false,
+    config: DEFAULT_COLUMN_CONFIG
+  },
+  CHECKBOX_TYPE: {
+    key: MetadataColumns.CHECKBOX_TYPE,
+    id: MetadataColumns.CHECKBOX_TYPE,
+    input: InputType.CHECKBOX_TYPE,
+    label: MetadataLabels.CHECKBOX_TYPE,
+    accessorKey: MetadataColumns.CHECKBOX_TYPE,
     isMetadata: true,
     isDragDisabled: false,
     skipPersist: false,
@@ -429,6 +444,7 @@ export const DEFAULT_SETTINGS: DatabaseSettings = {
     show_metadata_inlinks: false,
     show_metadata_outlinks: false,
     show_metadata_tags: false,
+    binary_checkbox_type: false,
     source_data: SourceDataTypes.CURRENT_FOLDER,
     source_form_result: '',
     source_destination_path: '/',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -281,6 +281,8 @@ export default {
   "settings_metatata_outlinks_toggle_desc": "Enable/disable File Outlinks Column",
   "settings_metatata_tags_toggle_title": "File Tags",
   "settings_metatata_tags_toggle_desc": "Enable/disable File Tags Column",
+  "settings_metatata_checkbox_type_toggle_title": "Checkbox Type",
+  "settings_metatata_checkbox_type_toggle_desc": "Select whether the cell state should be a boolean (true/false) or binary (1/0) in the frontmatter",
   "settings_remove_fields_title": "Remove fields",
   "settings_remove_fields_desc": "Enable/disable remove fields when a column is deleted",
   "settings_template_title": "Header templates",

--- a/src/settings/handlers/columns/DefaultMetadataToggleGroupHandler.ts
+++ b/src/settings/handlers/columns/DefaultMetadataToggleGroupHandler.ts
@@ -2,6 +2,7 @@ import { t } from "lang/helpers";
 import { Setting } from "obsidian";
 import { AbstractSettingsHandler, SettingHandlerResponse } from "settings/handlers/AbstractSettingHandler";
 import { add_setting_header } from "settings/SettingsComponents";
+import {DEFAULT_SETTINGS} from "../../../helpers/Constants";
 
 export class DefaultMetadataToggleGroupHandler extends AbstractSettingsHandler {
     settingTitle: string = t("settings_metatata_title");
@@ -136,6 +137,28 @@ export class DefaultMetadataToggleGroupHandler extends AbstractSettingsHandler {
                 .addToggle(toggle =>
                     toggle.setValue(settingsManager.plugin.settings.local_settings.show_metadata_tags)
                         .onChange(metadata_tags_toggle_promise)
+                );
+
+            /*************************
+             * CHECKBOX TYPE COLUMN
+             ************************/
+            const metadata_checkbox_type_toggle_promise = async (value: boolean): Promise<void> => {
+                // switch show tags on/off
+                const update_local_settings = settingsManager.plugin.settings.local_settings;
+                update_local_settings.binary_checkbox_type = value;
+                // update settings
+                await settingsManager.plugin.updateSettings({
+                    local_settings: update_local_settings
+                });
+                DEFAULT_SETTINGS.local_settings.binary_checkbox_type = value;
+            }
+
+            new Setting(metadata_section)
+                .setName(t("settings_metatata_checkbox_type_toggle_title"))
+                .setDesc(t("settings_metatata_checkbox_type_toggle_desc"))
+                .addToggle(toggle =>
+                    toggle.setValue(settingsManager.plugin.settings.local_settings.binary_checkbox_type)
+                        .onChange(metadata_checkbox_type_toggle_promise)
                 );
         }
         return this.goNext(settingHandlerResponse);


### PR DESCRIPTION
We're excited to announce the latest version of DB Folder, which introduces a new feature that makes it easier to integrate your notes with the [Obsidian Tracker](https://github.com/pyrochlore/obsidian-tracker) plugin. You can now configure the CheckBox type as either binary (1/0) or boolean (true/false), allowing you to use your note's frontmatter in a way that works best for you.

To configure the CheckBox type, simply go to the settings page and select the appropriate option. Once set, all notes using the CheckBox feature will use the selected type.

![Haabit Tracker Binary Option](https://user-images.githubusercontent.com/55400451/236966009-763503f2-61f5-446d-98e2-5687008b1241.gif)

We hope this new feature makes it easier for you to track your progress and achieve your goals with Obsidian.