### PR TITLE
Remove space reserved for scrollbar in database cell markdown

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -244,6 +244,7 @@ div.database-plugin__td.data-input span:focus {
 .database-plugin__markdown-preview-view {
   padding: 0;
   height: fit-content;
+  scrollbar-gutter: auto;
 }
 
 .svg-icon-sm svg {


### PR DESCRIPTION
## Without the change:
![image](https://github.com/RafaelGB/obsidian-db-folder/assets/28568841/73fe85da-baf4-4497-83aa-1b9396a17dfc)

Notice the green 'padding' space meaning that markdown text is not properly centered. 

## With the change:
![image](https://github.com/RafaelGB/obsidian-db-folder/assets/28568841/41896727-9ee2-4d9f-9d77-92159c455b62)

Notice that markdown text is properly centered, including the 'Select' labels' text. 