### PR TITLE
Adding support for helpUrl

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -7,5 +7,6 @@
 	"author": "RafaelGB",
 	"authorUrl": "https://github.com/RafaelGB/obsidian-bd-folder",
 	"isDesktopOnly": false,
-	"fundingUrl": "https://www.buymeacoffee.com/5tsytn22v9Z"
+	"fundingUrl": "https://www.buymeacoffee.com/5tsytn22v9Z",
+	"helpUrl": "https://rafaelgb.github.io/obsidian-db-folder/"
 }


### PR DESCRIPTION
I am adding helpUrl to the manifest to support the help system integration into Obsidian. Please consider supporting this initiative. Just so you know, this key value in manifest.json must be in the manifest downloaded as part of the plugin in the release.

https://forum.obsidian.md/t/links-to-help-and-manuals-for-plugins-and-themes/70733/8