### PR TITLE
Fix File Name Toggle not updating ColumnProperties properly

### DIFF
--- a/src/components/modals/newColumn/handlers/MetadataToggleGroupHandler.ts
+++ b/src/components/modals/newColumn/handlers/MetadataToggleGroupHandler.ts
@@ -20,7 +20,7 @@ export class MetadataToggleGroupHandler extends AbstractHandlerClass<AddColumnMo
          *************************/
         const metadata_file_toggle_promise = async (value: boolean): Promise<void> => {
             // Persist value
-            await view.diskConfig.updateColumnProperties(MetadataColumns.FILE, { isHidden: value });
+            await view.diskConfig.updateColumnProperties(MetadataColumns.FILE, { isHidden: !value });
             addColumnModalManager.addColumnModal.enableReset = true;
         }
         new Setting(metadata_section)


### PR DESCRIPTION
Resolves  #1029 

## Bug :
The File name toggle was being updated as isHidden not !isHidden, while the UI element is being updated as !isHidden.

This particular part of the codebase is confusing due to the File name following a different convention to track if it is hidden or not than all other properties. All other properties use the config propriety show_metadata_**_NAME_** to determine the toggle state which is true when the toggle should be on, however, the File property uses isHidden directly causing the toggle to be on when the isHidden bool is False. 

Given enough dev time I think it would be a good idea to refactor the Name metadata to be tracked and handled the same way that other metadata is handled.

## Fix
isHidden Value is set to !isHidden both during toggle render and in the present variable


## Temp fix for users until new build is deployed
You can double toggle to get the desired result of a single toggle.



My apologies for not going through the official pipeline to requesting the ability to work on an issue. I ended up reading the contribution guidelines after I had already forked and found the solution. 
