### PR TITLE
🛠️ Fix: update value with full path when creating new note in relation field

### DIFF
--- a/src/components/cellTypes/Editor/RelationEditor.tsx
+++ b/src/components/cellTypes/Editor/RelationEditor.tsx
@@ -33,10 +33,17 @@ const RelationEditor = (props: RelationEditorComponentProps) => {
   ) => {
     switch (actionMeta.action) {
       case "create-option":
-        await RelationalService.createNoteIntoRelation(
+        const newNotePath = await RelationalService.createNoteIntoRelation(
           tableColumn.config.related_note_path,
           actionMeta.option.value
         );
+        // Once the note is created, we need to update the value of the new option
+        const newOption = newValue.find(
+          (option) => option.value === actionMeta.option.value
+        );
+        if (newOption) {
+          newOption.value = newNotePath;
+        }
         break;
       default:
       // Do nothing

--- a/src/services/RelationalService.ts
+++ b/src/services/RelationalService.ts
@@ -79,7 +79,7 @@ class RelationalServiceInstance {
      * @param ddbbPath 
      * @param content 
      */
-    public async createNoteIntoRelation(ddbbPath: string, newFilename: string): Promise<void> {
+    public async createNoteIntoRelation(ddbbPath: string, newFilename: string): Promise<string> {
         LOGGER.info(`--> createNoteIntoRelation. Creating note ${newFilename} into relation ${ddbbPath}`);
         const ddbbFile = resolve_tfile(ddbbPath);
         const ddbbInfo = await new DatabaseInfo(ddbbFile, DEFAULT_SETTINGS.local_settings).build();

--- a/src/services/RelationalService.ts
+++ b/src/services/RelationalService.ts
@@ -3,7 +3,7 @@ import { TableColumn } from "cdm/FolderModel";
 import { LocalSettings } from "cdm/SettingsModel";
 import { obtainColumnsFromFolder, obtainColumnsFromRows } from "components/Columns";
 import { DatabaseCore, DEFAULT_SETTINGS } from "helpers/Constants";
-import { resolve_tfile } from "helpers/FileManagement";
+import { destination_folder, resolve_tfile } from "helpers/FileManagement";
 import { adapterTFilesToRows } from "helpers/VaultManagement";
 import { SMarkdownPage } from "obsidian-dataview";
 import { dataApiBuilder } from "views/DataApiBuilder";
@@ -87,6 +87,9 @@ class RelationalServiceInstance {
         const relatedColumns = await obtainColumnsFromFolder(ddbbInfo.yaml.columns);
         await dataApi.create(newFilename, relatedColumns, ddbbInfo.yaml.config);
         LOGGER.info(`<-- createNoteIntoRelation. Note ${newFilename} created into relation ${ddbbPath}`);
+        const dest_folder = destination_folder(ddbbFile, ddbbInfo.yaml.config);
+        const newNotePath = `${dest_folder}/${newFilename}.md`;
+        return newNotePath;
     }
 
     /**


### PR DESCRIPTION
🐛 Problem
When creating a new note via a Relation column with the bidirectional option enabled, the new note is successfully created in the related database — but the selected option’s value is not updated with the full path to the note. This results in a broken bidirectional relation and an error in the console.

💥 How to Reproduce
Create a Relation column in a DB Folder database with the bidirectional option enabled.

In the table view, go to a cell in that Relation column, type the name of a new note (that doesn't yet exist).

Click Create "note name" when prompted.

Click outside the cell.

Observe:

A console error is thrown.

The new note is created, but the relation option isn't properly updated (value is incomplete), so the bidirectional link fails.

✅ Fix Summary
Modified RelationalServiceInstance.createNoteIntoRelation to return the full path of the newly created note.

In RelationEditor.handleOnChange, during the create-option action, the returned path is now assigned to the correct value field in the newValue array, ensuring the relation is fully functional.

📷 Screenshots (Bug Reproduction)
Screenshot 01 – Relation Settings
Shows the configuration of the relation column with bidirectional enabled.

Screenshot 02 – Creating a New Note in the Related Database
Typing a new note name and selecting Create "note name".

Screenshot 03 – Clicking Away
After clicking away, the note is created but a console error appears. The relation value is not updated correctly.

(Screenshots attached below)

Screenshot 01 - Relation Settings
<img width="958" alt="{61350E88-7F5F-46C5-AC2C-D92C8F629995}" src="https://github.com/user-attachments/assets/b9e27047-af99-4daf-9ad3-ee3bca409a67" />

Screenshot 02 - Creating a new note in the related database
<img width="438" alt="{E0F3E71A-8C91-4D8F-BECD-0751D6B781D2}" src="https://github.com/user-attachments/assets/bc02d746-8f4f-4128-b8d6-9b86f0b173c2" />

Screenshot 03 - Clicking away
<img width="960" alt="{81BC9B47-5ABD-4A44-A532-4E158E9B2DB3}" src="https://github.com/user-attachments/assets/0644faff-53c2-485d-9325-eb0ddf70ede3" />


PS: Tis is the first PR i send to a public repo, so let me know anything i could do to make it work for you, i would be very grateful. Thank you for your work making this useful plugin!
